### PR TITLE
Make 'sources' understand file-like objects

### DIFF
--- a/README
+++ b/README
@@ -2,4 +2,4 @@ ConfigFile class - Dynamically parse and edit configuration files.
 
 License: GPLv3 (see LICENSE).
 
-Documentation: http://kynikos.github.io/lib.py.configfile/
+Documentation: https://kynikos.github.io/lib.py.configfile/


### PR DESCRIPTION
It would be nice if the 'sources' parameter could understand already-created file-like objects, e.g. files open by some other library or "virtual" streams. This works nicely for my use case, but you may need to update some other parts (including the top-level documentation).

In the future it would be even nicer to expose the same types for serialization, i.e. export to targets specified by file names, file-like objects, dictionaries etc. But I'm nowhere near testing this part yet...
